### PR TITLE
install from local source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,6 @@ RUN apt-get update && \
     apt-get install -y ${PACKAGES} && \
     apt-get clean
 
-#RUN pip3 install tcrmatch
+RUN mkdir /TCRMatch
+COPY . /TCRMatch
+RUN cd /TCRMatch && python3 setup.py install


### PR DESCRIPTION
@acrinklaw Here's a little change to Dockerfile so that it installs from local source.

If you will be using docker hub to distribute releases, the typical workflow is to setup autobuild in docker hub based upon github tags versus using pip.