### PR TITLE
attempting fix for push to harbor

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   REGISTRY: harbor.lji.org
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: iedb-public/tcrmatch
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
It looks like the registry name changed from 'iedb' to 'iedb-public' on the harbor.lji.org server some time back, so I went ahead and updated the name in the actions file.  Hopefully this will get the pushes to harbor working again.